### PR TITLE
chore: enable allowSyntheticDefaultImports

### DIFF
--- a/lib/getTSCommonConfig.js
+++ b/lib/getTSCommonConfig.js
@@ -6,5 +6,6 @@ module.exports = function () {
     jsx: 'preserve',
     moduleResolution: 'node',
     declaration: true,
+    allowSyntheticDefaultImports: true,
   };
 };


### PR DESCRIPTION
支持以下写法：

```jsx
import React from 'react';
```