### PR TITLE
Replace assign with deepAssign

### DIFF
--- a/lib/getWebpackConfig.js
+++ b/lib/getWebpackConfig.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const webpack = require('atool-build/lib/webpack');
+const deepAssign = require('deep-assign');
 
 const packageName = require(path.join(process.cwd(), 'package.json')).name;
 
@@ -71,7 +72,7 @@ module.exports = function (webpackConfig) {
       '\n\nCopyright 2015-present, Alipay, Inc.\nAll rights reserved.'
     ));
 
-    const uncompressedWebpackConfig = Object.assign({}, webpackConfig);
+    const uncompressedWebpackConfig = deepAssign({}, webpackConfig);
     uncompressedWebpackConfig.entry = {
       [packageName]: entry,
     };

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "chalk": "~1.1.3",
     "colorful": "^2.1.0",
     "commander": "^2.9.0",
+    "deep-assign": "^2.0.0",
     "es3ify": "^0.2.1",
     "es3ify-loader": "^0.2.0",
     "gh-pages": "^0.11.0",


### PR DESCRIPTION
Object.assign 会导致修改 `webpackConfig`  里的内容的时候把 `uncompressedWebpackConfig` 里的内容也修改掉。


比如这里 https://github.com/ant-design/ant-design/blob/master/webpack.config.js#L15-L18 其实会在 `uncompressedWebpackConfig` 塞两个 `es3ify-loader` 进去。