### PR TITLE
Add babel-plugin-import to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "atool-build": "^0.9.0",
     "babel-eslint": "^7.1.0",
+    "babel-plugin-import": "^1.1.1",
     "babel-plugin-transform-runtime": "~6.12.0",
     "chalk": "~1.1.3",
     "colorful": "^2.1.0",


### PR DESCRIPTION
antd-tools [依赖](https://github.com/ant-design/antd-tools/blob/master/lib/getWebpackConfig.js#L26) 它，但是却写在 antd 的 devDependencies  里。