### PR TITLE
fix: jsx-wrap-multiline

### DIFF
--- a/lib/tslint.json
+++ b/lib/tslint.json
@@ -143,6 +143,7 @@
     ],
     "jsx-no-lambda": false,
     "jsx-no-string-ref": false,
-    "jsx-boolean-value": "never"
+    "jsx-boolean-value": "never",
+    "jsx-wrap-multiline": false,
   }
 }


### PR DESCRIPTION
https://github.com/palantir/tslint-react/issues/79

先关闭 jsx-wrap-multiline，以便于趁早把 https://github.com/ant-design/ant-design-mobile/pull/1051  
 合并