### PR TITLE
Create GitHub release

### DIFF
--- a/lib/gulpfile.js
+++ b/lib/gulpfile.js
@@ -10,12 +10,14 @@ const transformLess = require('./transformLess');
 const webpack = require('webpack');
 const babel = require('gulp-babel');
 const argv = require('minimist')(process.argv.slice(2));
+const GitHub = require('github');
 
 const packageJson = require(`${process.cwd()}/package.json`);
 const getNpm = require('./getNpm');
 const selfPackage = require('../package.json');
 const chalk = require('chalk');
 const getNpmArgs = require('./utils/get-npm-args');
+const getChangelog = require('./utils/getChangelog');
 const path = require('path');
 const watch = require('gulp-watch');
 const ts = require('gulp-typescript');
@@ -75,6 +77,49 @@ function tag() {
   execSync(`git push origin ${version}:${version}`);
   execSync('git push origin master:master');
   console.log('tagged');
+}
+
+function githubRelease() {
+  const changlogFiles = [
+    path.join(cwd, 'CHANGELOG.en-US.md'),
+    path.join(cwd, 'CHANGELOG.zh-CN.md'),
+  ];
+  console.log('creating release on GitHub');
+  if (!process.env.GITHUB_TOKEN) {
+    console.log('no GitHub token found, skip');
+    return;
+  }
+  if (!changlogFiles.every(file => fs.existsSync(file))) {
+    console.log('no changelog found, skip');
+    return;
+  }
+  const github = new GitHub();
+  github.authenticate({
+    type: 'oauth',
+    token: process.env.GITHUB_TOKEN,
+  });
+  const date = new Date();
+  const { version } = packageJson;
+  const enChangelog = getChangelog(changlogFiles[0], version);
+  const cnChangelog = getChangelog(changlogFiles[1], version);
+  const changelog = [
+    `\`${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}\``,
+    enChangelog,
+    '\n',
+    '---',
+    '\n',
+    cnChangelog,
+  ].join('\n');
+  const [_, owner, repo] = execSync('git remote get-url origin') // eslint-disable-line
+    .toString()
+    .match(/github.com:(.+)\/(.+)\.git/);
+  github.repos.createRelease({
+    owner,
+    repo,
+    tag_name: version,
+    name: version,
+    body: changelog,
+  });
 }
 
 gulp.task('check-git', (done) => {
@@ -254,6 +299,7 @@ function publish(tagString, done) {
   const publishNpm = process.env.PUBLISH_NPM_CLI || 'npm';
   runCmd(publishNpm, args, (code) => {
     tag();
+    githubRelease();
     done(code);
   });
 }

--- a/lib/utils/getChangelog.js
+++ b/lib/utils/getChangelog.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+
+module.exports = function getChangelog(file, version) {
+  const lines = fs.readFileSync(file).toString().split('\n');
+  const changeLog = [];
+  const startPattern = new RegExp(`^## ${version}`);
+  const stopPattern = /^## /; // 前一个版本
+  const skipPattern = /^`/; // 日期
+  let begin = false;
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (begin && stopPattern.test(line)) {
+      break;
+    }
+    if (begin && line && !skipPattern.test(line)) {
+      changeLog.push(line);
+    }
+    if (!begin) {
+      begin = startPattern.test(line);
+    }
+  }
+  return changeLog.join('\n');
+};

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "extract-text-webpack-plugin": "^3.0.0",
     "friendly-errors-webpack-plugin": "^1.6.1",
     "gh-pages": "^1.0.0",
+    "github": "^13.1.0",
     "gulp": "^3.9.1",
     "gulp-babel": "^7.0.0",
     "gulp-strip-code": "^0.1.4",


### PR DESCRIPTION
发布时自动创建 GitHub release。

需要先在 GitHub 上[创建一个 token](https://github.com/settings/tokens)，钩上 `repo.public_repo`。

在 `~/.zshrc` 或 `~/.bashrc` 里加上:

```bash
export GITHUB_TOKE=创建的 token
```

`npm run pub` 时会自动从 CHAGELOG 里读内容创建 release。