### PR TITLE
add libraryName arg in getWebpackConfig

### DIFF
--- a/lib/getWebpackConfig.js
+++ b/lib/getWebpackConfig.js
@@ -7,19 +7,20 @@ const chalk = require('chalk');
 const replaceLib = require('./replaceLib');
 const postcssConfig = require('./postcssConfig');
 
-module.exports = function (modules) {
+module.exports = function (modules, libraryName) {
   const pkg = require(path.join(process.cwd(), 'package.json'));
+  libraryName = libraryName || 'antd';
   const babelConfig = require('./getBabelCommonConfig')(modules || false);
 
   const pluginImportOptions = [
     {
       style: true,
-      libraryName: pkg.name,
+      libraryName,
       libraryDirectory: 'components',
     },
   ];
 
-  if (pkg.name !== 'antd') {
+  if (libraryName !== 'antd') {
     pluginImportOptions.push({
       style: 'css',
       libraryDirectory: 'es',
@@ -58,7 +59,7 @@ module.exports = function (modules) {
         '.json',
       ],
       alias: {
-        [pkg.name]: process.cwd(),
+        [libraryName]: process.cwd(),
       },
     },
 
@@ -179,7 +180,7 @@ All rights reserved.
   if (process.env.RUN_ENV === 'PRODUCTION') {
     const entry = ['./index'];
     config.entry = {
-      [`${pkg.name}.min`]: entry,
+      [`${libraryName}.min`]: entry,
     };
     config.externals = {
       react: {
@@ -195,7 +196,7 @@ All rights reserved.
         amd: 'react-dom',
       },
     };
-    config.output.library = pkg.name;
+    config.output.library = libraryName;
     config.output.libraryTarget = 'umd';
 
     const uncompressedConfig = deepAssign({}, config);
@@ -220,7 +221,7 @@ All rights reserved.
     ]);
 
     uncompressedConfig.entry = {
-      [pkg.name]: entry,
+      [libraryName]: entry,
     };
 
     uncompressedConfig.plugins.push(new webpack.DefinePlugin({


### PR DESCRIPTION
I have modified some usages of `pkg.name`. 

Because if the `pkg.name` is not 'antd', there are many of errors when running test tasks in antd project.  The ant-tools supports changing `pkg.name`, but codes about test in antd do not support.

In my option, the `pkg.name` called 'antd' is best.