### PR TITLE
fix: tslint trailling-comma rule needs to be esSpecCompliant

### DIFF
--- a/lib/tslint.json
+++ b/lib/tslint.json
@@ -94,7 +94,8 @@
       true,
       {
         "singleline": "never",
-        "multiline": "always"
+        "multiline": "always",
+        "esSpecCompliant": true
       }
     ],
     "triple-equals": [


### PR DESCRIPTION
Otherwise it will complain `...rest` needs a trailing comma