### PR TITLE
FIx IE problem

### DIFF
--- a/lib/getBabelCommonConfig.js
+++ b/lib/getBabelCommonConfig.js
@@ -13,6 +13,12 @@ module.exports = function(modules) {
     resolve('@babel/plugin-proposal-export-namespace-from'),
     resolve('@babel/plugin-proposal-object-rest-spread'),
     [
+      resolve('@babel/plugin-transform-classes'),
+      {
+        loose: true,
+      },
+    ],
+    [
       resolve('@babel/plugin-proposal-decorators'),
       {
         decoratorsBeforeExport: true,

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@babel/plugin-proposal-export-default-from": "^7.2.0",
     "@babel/plugin-proposal-export-namespace-from": "^7.2.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.2.0",
+    "@babel/plugin-transform-classes": "^7.2.0",
     "@babel/plugin-transform-member-expression-literals": "^7.2.0",
     "@babel/plugin-transform-object-assign": "^7.2.0",
     "@babel/plugin-transform-property-literals": "^7.2.0",


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/13540
 IE9 and IE10 doesn't like props to be used in the constructor of a react component but will allow the use of props in other component methods.
Has anyone tested in IE9 and IE10 ?