### PR TITLE
fix babel7 duplicate plugin verification

### DIFF
--- a/lib/getWebpackConfig.js
+++ b/lib/getWebpackConfig.js
@@ -50,6 +50,7 @@ function getWebpackConfig(modules) {
         libraryDirectory: 'es',
         libraryName: 'antd',
       },
+      'other-package-babel-plugin-import'
     ]);
   }
 


### PR DESCRIPTION
When I use antd-tools in a project whose pkg.name !== 'antd', it will cause an error in babel's duplicate plugin verification.
```
 // babel import for components
  babelConfig.plugins.push([
    resolve('babel-plugin-import'),
    {
      style: true,
      libraryName: pkg.name,
      libraryDirectory: 'components',
    },
  ]);

  // Other package
  if (pkg.name !== 'antd') {
    babelConfig.plugins.push([
      resolve('babel-plugin-import'), // duplicate import 'babel-plugin-import' plugin without unique name
      {
        style: 'css',
        libraryDirectory: 'es',
        libraryName: 'antd',
      },
    ]);
  }
```
[antd-tools code](https://github.com/ant-design/antd-tools/blob/e0242e06c53c243554ef5d21b3f9dafa7160c1f5/lib/getWebpackConfig.js#L45)
[babel code](https://github.com/babel/babel/blob/3a399d1eb907df520f2b85bf9ddbc6533e256f6d/packages/babel-core/src/config/config-descriptors.js#L348)
