### PR TITLE
Do not tag if parent cmd failed

### DIFF
--- a/lib/getWebpackConfig.js
+++ b/lib/getWebpackConfig.js
@@ -14,7 +14,7 @@ const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
-const FilterWarningsPlugin = require( 'webpack-filter-warnings-plugin' );
+const FilterWarningsPlugin = require('webpack-filter-warnings-plugin');
 const postcssConfig = require('./postcssConfig');
 const CleanUpStatsPlugin = require('./utils/CleanUpStatsPlugin');
 
@@ -192,9 +192,9 @@ All rights reserved.
       new FilterWarningsPlugin({
         // suppress conflicting order warnings from mini-css-extract-plugin.
         // ref: https://github.com/ant-design/ant-design/issues/14895
-				// see https://github.com/webpack-contrib/mini-css-extract-plugin/issues/250
-				exclude: /mini-css-extract-plugin[^]*Conflicting order between:/,
-			}),
+        // see https://github.com/webpack-contrib/mini-css-extract-plugin/issues/250
+        exclude: /mini-css-extract-plugin[^]*Conflicting order between:/,
+      }),
     ],
 
     performance: {

--- a/lib/gulpfile.js
+++ b/lib/gulpfile.js
@@ -290,7 +290,7 @@ function publish(tagString, done) {
   }
   const publishNpm = process.env.PUBLISH_NPM_CLI || 'npm';
   runCmd(publishNpm, args, code => {
-    if (!argv['skip-tag']) {
+    if (!argv['skip-tag'] && !code) {
       tag();
     }
     done(code);

--- a/lib/lint/checkDeps.js
+++ b/lib/lint/checkDeps.js
@@ -162,7 +162,8 @@ module.exports = function(done) {
 
     let progressBar;
     if (useTerminal) {
-      progressBar = !argv.debug &&
+      progressBar =
+        !argv.debug &&
         new ProgressBar('Processing [:bar] :percent (:current/:total)', {
           complete: '=',
           incomplete: ' ',


### PR DESCRIPTION
Current logic will tag whatever npm publish success or not.