### PR TITLE
Add dist finalize script & support package file diff

### DIFF
--- a/lib/gulpfile.js
+++ b/lib/gulpfile.js
@@ -27,6 +27,7 @@ const { cssInjection } = require('./utils/styleUtil');
 const tsConfig = require('./getTSCommonConfig')();
 const replaceLib = require('./replaceLib');
 const checkDeps = require('./lint/checkDeps');
+const checkDiff = require('./lint/checkDiff');
 
 const packageJson = require(getProjectPath('package.json'));
 
@@ -305,6 +306,14 @@ function publish(tagString, done) {
   });
 }
 
+// We use https://unpkg.com/[name]/?meta to check exist files
+gulp.task(
+  'package-diff',
+  gulp.series(done => {
+    checkDiff(packageJson.name, done);
+  })
+);
+
 function pub(done) {
   const notOk = !packageJson.version.match(/^\d+\.\d+\.\d+$/);
   let tagString;
@@ -348,7 +357,7 @@ gulp.task(
 
 gulp.task(
   'pub',
-  gulp.series('check-git', 'compile', 'dist', done => {
+  gulp.series('check-git', 'compile', 'dist', 'package-diff', done => {
     pub(done);
   })
 );

--- a/lib/gulpfile.js
+++ b/lib/gulpfile.js
@@ -1,4 +1,4 @@
-const { getProjectPath, injectRequire } = require('./utils/projectHelper'); // eslint-disable-line import/order
+const { getProjectPath, injectRequire, getConfig } = require('./utils/projectHelper'); // eslint-disable-line import/order
 
 injectRequire();
 
@@ -68,6 +68,14 @@ function dist(done) {
       version: false,
     });
     console.log(buildInfo);
+
+    // Additional process of dist finalize
+    const { dist: { finalize } = {} } = getConfig();
+    if (finalize) {
+      console.log('[Dist] Finalization...');
+      finalize();
+    }
+
     done(0);
   });
 }

--- a/lib/gulpfile.js
+++ b/lib/gulpfile.js
@@ -306,31 +306,25 @@ function publish(tagString, done) {
 }
 
 function pub(done) {
-  dist(code => {
-    if (code) {
-      done(code);
-      return;
-    }
-    const notOk = !packageJson.version.match(/^\d+\.\d+\.\d+$/);
-    let tagString;
-    if (argv['npm-tag']) {
-      tagString = argv['npm-tag'];
-    }
-    if (!tagString && notOk) {
-      tagString = 'next';
-    }
-    if (packageJson.scripts['pre-publish']) {
-      runCmd('npm', ['run', 'pre-publish'], code2 => {
-        if (code2) {
-          done(code2);
-          return;
-        }
-        publish(tagString, done);
-      });
-    } else {
+  const notOk = !packageJson.version.match(/^\d+\.\d+\.\d+$/);
+  let tagString;
+  if (argv['npm-tag']) {
+    tagString = argv['npm-tag'];
+  }
+  if (!tagString && notOk) {
+    tagString = 'next';
+  }
+  if (packageJson.scripts['pre-publish']) {
+    runCmd('npm', ['run', 'pre-publish'], code2 => {
+      if (code2) {
+        done(code2);
+        return;
+      }
       publish(tagString, done);
-    }
-  });
+    });
+  } else {
+    publish(tagString, done);
+  }
 }
 
 gulp.task('compile-with-es', done => {
@@ -354,7 +348,7 @@ gulp.task(
 
 gulp.task(
   'pub',
-  gulp.series('check-git', 'compile', done => {
+  gulp.series('check-git', 'compile', 'dist', done => {
     pub(done);
   })
 );

--- a/lib/lint/checkDiff.js
+++ b/lib/lint/checkDiff.js
@@ -33,14 +33,19 @@ module.exports = function(packageName, done) {
       const missingFiles = fileList.filter(filePath => !fs.existsSync(getProjectPath(filePath)));
 
       if (missingFiles.length) {
-        console.log(chalk.red(`⚠️  Some file missing in current build (last version: ${version}):`));
+        console.log(
+          chalk.red(`⚠️  Some file missing in current build (last version: ${version}):`)
+        );
         missingFiles.forEach(filePath => {
           console.log(` - ${filePath}`);
         });
         return Promise.reject('Please double confirm with files.'); // eslint-disable-line prefer-promise-reject-errors
       }
 
-      console.log(chalk.green('✅ Nothing missing compare to latest version:'), chalk.yellow(version));
+      console.log(
+        chalk.green('✅ Nothing missing compare to latest version:'),
+        chalk.yellow(version)
+      );
       return 0;
     })
     .then(done)

--- a/lib/lint/checkDiff.js
+++ b/lib/lint/checkDiff.js
@@ -1,0 +1,70 @@
+const { getProjectPath } = require('../utils/projectHelper'); // eslint-disable-line import/order
+
+const fs = require('fs');
+const chalk = require('chalk');
+const fetch = require('node-fetch');
+const readline = require('readline');
+
+module.exports = function(packageName, done) {
+	console.log(chalk.cyan('Fetching latest version file list...'));
+	fetch(`https://unpkg.com/${packageName}/?meta`)
+		.then((res) => res.json())
+		.then(({ files: pkgFiles }) => {
+			// Loop all the exist files
+			function flattenPath(files, fileList = []) {
+				(files || []).forEach(({ path, files: subFiles }) => {
+					fileList.push(path);
+					flattenPath(subFiles, fileList);
+				});
+				return fileList;
+			}
+			return flattenPath(pkgFiles);
+		})
+		.then((fileList) => {
+			// Find missing files
+			const missingFiles = fileList.filter((filePath) => !fs.existsSync(getProjectPath(filePath)));
+
+			if (missingFiles.length) {
+        console.log(chalk.yellow('⚠️  Some file missing in current build:'));
+        missingFiles.forEach(filePath => {
+          console.log(` - ${filePath}`);
+        });
+        return Promise.reject('Please double confirm with files.'); // eslint-disable-line prefer-promise-reject-errors
+			}
+
+      console.log(chalk.green('✅ Nothing missing with latest version.'));
+      return 0;
+		})
+		.then(done)
+		.catch((err) => {
+      console.error(err);
+      console.log(chalk.yellow('\nNeed confirm for file diff:'));
+
+      function userConfirm() {
+        const rl = readline.createInterface({
+          input: process.stdin,
+          output: process.stdout,
+        });
+        rl.question([
+          'Type "YES" to confirm it is safe.',
+          'Type "NO" to fail this check.',
+          '',
+        ].join('\n'), (answer) => {
+          rl.close();
+
+          if (answer === 'YES') {
+            console.log(chalk.green('✅ Confirm it is OK.'));
+            done();
+          } else if (answer === 'NO') {
+            console.log(chalk.red('🚫 Aha! Catch you!'));
+            done(1);
+          } else {
+            console.log(chalk.yellow('Invalidate input. Type again!'));
+            userConfirm();
+          }
+        });
+      }
+
+      userConfirm();
+		});
+};

--- a/lib/lint/checkDiff.js
+++ b/lib/lint/checkDiff.js
@@ -6,37 +6,37 @@ const fetch = require('node-fetch');
 const readline = require('readline');
 
 module.exports = function(packageName, done) {
-	console.log(chalk.cyan('Fetching latest version file list...'));
-	fetch(`https://unpkg.com/${packageName}/?meta`)
-		.then((res) => res.json())
-		.then(({ files: pkgFiles }) => {
-			// Loop all the exist files
-			function flattenPath(files, fileList = []) {
-				(files || []).forEach(({ path, files: subFiles }) => {
-					fileList.push(path);
-					flattenPath(subFiles, fileList);
-				});
-				return fileList;
-			}
-			return flattenPath(pkgFiles);
-		})
-		.then((fileList) => {
-			// Find missing files
-			const missingFiles = fileList.filter((filePath) => !fs.existsSync(getProjectPath(filePath)));
+  console.log(chalk.cyan('Fetching latest version file list...'));
+  fetch(`https://unpkg.com/${packageName}/?meta`)
+    .then(res => res.json())
+    .then(({ files: pkgFiles }) => {
+      // Loop all the exist files
+      function flattenPath(files, fileList = []) {
+        (files || []).forEach(({ path, files: subFiles }) => {
+          fileList.push(path);
+          flattenPath(subFiles, fileList);
+        });
+        return fileList;
+      }
+      return flattenPath(pkgFiles);
+    })
+    .then(fileList => {
+      // Find missing files
+      const missingFiles = fileList.filter(filePath => !fs.existsSync(getProjectPath(filePath)));
 
-			if (missingFiles.length) {
+      if (missingFiles.length) {
         console.log(chalk.yellow('⚠️  Some file missing in current build:'));
         missingFiles.forEach(filePath => {
           console.log(` - ${filePath}`);
         });
         return Promise.reject('Please double confirm with files.'); // eslint-disable-line prefer-promise-reject-errors
-			}
+      }
 
       console.log(chalk.green('✅ Nothing missing with latest version.'));
       return 0;
-		})
-		.then(done)
-		.catch((err) => {
+    })
+    .then(done)
+    .catch(err => {
       console.error(err);
       console.log(chalk.yellow('\nNeed confirm for file diff:'));
 
@@ -45,26 +45,25 @@ module.exports = function(packageName, done) {
           input: process.stdin,
           output: process.stdout,
         });
-        rl.question([
-          'Type "YES" to confirm it is safe.',
-          'Type "NO" to fail this check.',
-          '',
-        ].join('\n'), (answer) => {
-          rl.close();
+        rl.question(
+          ['Type "YES" to confirm it is safe.', 'Type "NO" to fail this check.', ''].join('\n'),
+          answer => {
+            rl.close();
 
-          if (answer === 'YES') {
-            console.log(chalk.green('✅ Confirm it is OK.'));
-            done();
-          } else if (answer === 'NO') {
-            console.log(chalk.red('🚫 Aha! Catch you!'));
-            done(1);
-          } else {
-            console.log(chalk.yellow('Invalidate input. Type again!'));
-            userConfirm();
+            if (answer === 'YES') {
+              console.log(chalk.green('✅ Confirm it is OK.'));
+              done();
+            } else if (answer === 'NO') {
+              console.log(chalk.red('🚫 Aha! Catch you!'));
+              done(1);
+            } else {
+              console.log(chalk.yellow('Invalidate input. Type again!'));
+              userConfirm();
+            }
           }
-        });
+        );
       }
 
       userConfirm();
-		});
+    });
 };

--- a/lib/lint/checkDiff.js
+++ b/lib/lint/checkDiff.js
@@ -25,7 +25,7 @@ module.exports = function(packageName, done) {
       const missingFiles = fileList.filter(filePath => !fs.existsSync(getProjectPath(filePath)));
 
       if (missingFiles.length) {
-        console.log(chalk.yellow('⚠️  Some file missing in current build:'));
+        console.log(chalk.red('⚠️  Some file missing in current build:'));
         missingFiles.forEach(filePath => {
           console.log(` - ${filePath}`);
         });

--- a/lib/lint/checkDiff.js
+++ b/lib/lint/checkDiff.js
@@ -5,11 +5,19 @@ const chalk = require('chalk');
 const fetch = require('node-fetch');
 const readline = require('readline');
 
+function getVersionFromURL(url, name) {
+  const affix = url.slice(url.indexOf(name) + name.length + 1);
+  return affix.slice(0, affix.indexOf('/'));
+}
+
 module.exports = function(packageName, done) {
   console.log(chalk.cyan('Fetching latest version file list...'));
   fetch(`https://unpkg.com/${packageName}/?meta`)
-    .then(res => res.json())
-    .then(({ files: pkgFiles }) => {
+    .then(res => {
+      const version = getVersionFromURL(res.url, packageName);
+      return res.json().then(json => ({ version, ...json }));
+    })
+    .then(({ version, files: pkgFiles }) => {
       // Loop all the exist files
       function flattenPath(files, fileList = []) {
         (files || []).forEach(({ path, files: subFiles }) => {
@@ -18,21 +26,21 @@ module.exports = function(packageName, done) {
         });
         return fileList;
       }
-      return flattenPath(pkgFiles);
+      return { version, fileList: flattenPath(pkgFiles) };
     })
-    .then(fileList => {
+    .then(({ version, fileList }) => {
       // Find missing files
       const missingFiles = fileList.filter(filePath => !fs.existsSync(getProjectPath(filePath)));
 
       if (missingFiles.length) {
-        console.log(chalk.red('⚠️  Some file missing in current build:'));
+        console.log(chalk.red(`⚠️  Some file missing in current build (last version: ${version}):`));
         missingFiles.forEach(filePath => {
           console.log(` - ${filePath}`);
         });
         return Promise.reject('Please double confirm with files.'); // eslint-disable-line prefer-promise-reject-errors
       }
 
-      console.log(chalk.green('✅ Nothing missing with latest version.'));
+      console.log(chalk.green('✅ Nothing missing compare to latest version:'), chalk.yellow(version));
       return 0;
     })
     .then(done)
@@ -46,7 +54,7 @@ module.exports = function(packageName, done) {
           output: process.stdout,
         });
         rl.question(
-          ['Type "YES" to confirm it is safe.', 'Type "NO" to fail this check.', ''].join('\n'),
+          ['Type "YES" to confirm it is safe.', 'Type "NO" to exit process.', ''].join('\n'),
           answer => {
             rl.close();
 

--- a/lib/utils/projectHelper.js
+++ b/lib/utils/projectHelper.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path');
 
 const cwd = process.cwd();
@@ -35,8 +36,18 @@ function injectRequire() {
   injected = true;
 }
 
+function getConfig() {
+  const configPath = getProjectPath('.antd-tools.config.js');
+  if (fs.existsSync(configPath)) {
+    return require(configPath);
+  }
+
+  return {};
+}
+
 module.exports = {
   getProjectPath,
   resolve,
   injectRequire,
+  getConfig,
 };

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "mini-css-extract-plugin": "^0.5.0",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
+    "node-fetch": "^2.3.0",
     "object-assign": "~4.1.1",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "postcss": "^7.0.6",


### PR DESCRIPTION
为了解决 #95 做了两件事情：
1. 添加一个 `.antd-tools.config.js` 配置文件支持，允许用户执行 `dist` 后运行额外的脚本。这样可以保证 dist 后执行额外的 index.less 文件生成。
2. 添加一个 `diff lint`，会从 `unpkg` 中拉取最新的文件列表。如果发现文件丢失，会暂停流程询问发布人员是否是故意的。直到发布人员明确输入 `YES` or `NO` 才会继续执行。

![Kapture 2019-04-02 at 11 59 34](https://user-images.githubusercontent.com/5378891/55376457-0f566200-5543-11e9-9707-33f2e04b85f0.gif)
![Kapture 2019-04-02 at 12 21 58](https://user-images.githubusercontent.com/5378891/55376473-18dfca00-5543-11e9-8956-21a31e5f5d0a.gif)
![Kapture 2019-04-02 at 12 26 07](https://user-images.githubusercontent.com/5378891/55376481-21380500-5543-11e9-98a5-b9714db998f6.gif)
