### PR TITLE
Fix antd test warning `__Demo`

### DIFF
--- a/lib/jest/demoPreprocessor.js
+++ b/lib/jest/demoPreprocessor.js
@@ -44,6 +44,8 @@ function createDemo({ types: t }) {
           const app = t.VariableDeclaration('const', [
             t.VariableDeclarator(t.Identifier('__Demo'), path.node.arguments[0]),
           ]);
+          // 参考 https://github.com/babel/babel/blob/8d492b159b342cfd1f399e4292e3cb12a895e1d3/packages/babel-plugin-transform-typescript/src/enum.js#L28
+          path.scope.registerDeclaration(path.replaceWith(app)[0]);
           const exportDefault = t.ExportDefaultDeclaration(t.Identifier('__Demo'));
           path.insertAfter(exportDefault);
           path.insertAfter(app);


### PR DESCRIPTION
修复 antd 测试 warning：

```
This problem is likely caused by another plugin injecting
"__Demo" without registering it in the scope tracker. If you are the author
 of that plugin, please use "scope.registerDeclaration(declarationPath)".
The exported identifier "__Demo" is not declared in Babel's scope tracker
as a JavaScript value binding, and "@babel/plugin-transform-typescript"
never encountered it as a TypeScript type declaration.
It will be treated as a JavaScript value.
```