### PR TITLE
support config tag

### DIFF
--- a/lib/gulpfile.js
+++ b/lib/gulpfile.js
@@ -314,9 +314,21 @@ gulp.task(
 function pub(done) {
   const notOk = !packageJson.version.match(/^\d+\.\d+\.\d+$/);
   let tagString;
+
+  // Argument tag
   if (argv['npm-tag']) {
     tagString = argv['npm-tag'];
   }
+
+  // Config tag
+  if (!tagString) {
+    const { tag: configTag } = getConfig();
+    if (configTag) {
+      tagString = configTag;
+    }
+  }
+
+  // Auto next tag
   if (!tagString && notOk) {
     tagString = 'next';
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/tools",
-  "version": "8.0.6",
+  "version": "8.1.0",
   "description": "tools for ant design",
   "keywords": [
     "react",


### PR DESCRIPTION
看了一圈似乎 npm 没有这个配置，在 `.antd-tools.config.js` 添加一个 `tag` 属性支持。