### PR TITLE
Add @babel/plugin-transform-typescript in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@babel/plugin-transform-runtime": "^7.4.4",
     "@babel/plugin-transform-spread": "^7.2.2",
     "@babel/plugin-transform-template-literals": "^7.4.4",
+    "@babel/plugin-transform-typescript": "^7.10.5",
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
     "ansi-styles": "^4.0.0",


### PR DESCRIPTION
As its try to get antd-tools/lib/getBabelCommonConfig.js
I think its should explicit declaration in package.json

Then its can fix miss dependency in ant-design which try to run compile