### PR TITLE
fix getWebpackConfig response if RUN_ENV is not dev

### DIFF
--- a/lib/getWebpackConfig.js
+++ b/lib/getWebpackConfig.js
@@ -288,7 +288,7 @@ All rights reserved.
     return [prodConfig, uncompressedConfig];
   }
 
-  return config;
+  return [config];
 }
 
 getWebpackConfig.webpack = webpack;


### PR DESCRIPTION
In the `ant-design` main repository the response of `getWebpackConfig` is expected to be an array:
https://github.com/ant-design/ant-design/blob/9b6db94fdf1cd0cda0f3de0a1f127ac6fd2fc77d/webpack.config.js#L89
It's using `forEach` on it and also it's spread in module.exports further down:
https://github.com/ant-design/ant-design/blob/9b6db94fdf1cd0cda0f3de0a1f127ac6fd2fc77d/webpack.config.js#L120

If the environment variable `RUN_ENV` is not `PRODUCTION` though, it's returning the config object and no array.

This PR fixes this inconsistency which breaks the build in case `RUN_ENV` is not `PRODUCTION`, see error below:

```
webpackConfig.forEach is not a function
       at Object.<anonymous> (/.../ant-design/webpack.config.js:89:15)
```

I checked the use of `getWebpackConfig` in the main repo and it seems that it's only used in the `webpack.config.js` file. Couldn't verify that this change doesn't break any other usage in other packages that might use this function.

The alternative would be to verify that the config is an array in the main repo or transform the value to an array if it is not.