### PR TITLE
feat: support read less opt

### DIFF
--- a/lib/gulpfile.js
+++ b/lib/gulpfile.js
@@ -16,7 +16,6 @@ const gulp = require('gulp');
 const fs = require('fs');
 const rimraf = require('rimraf');
 const stripCode = require('gulp-strip-code');
-const concat = require('gulp-concat');
 const install = require('./install');
 const runCmd = require('./runCmd');
 const getBabelCommonConfig = require('./getBabelCommonConfig');
@@ -38,7 +37,6 @@ const tsDefaultReporter = ts.reporter.defaultReporter();
 const cwd = process.cwd();
 const libDir = getProjectPath('lib');
 const esDir = getProjectPath('es');
-const distDir = getProjectPath('dist');
 
 function dist(done) {
   rimraf.sync(getProjectPath('dist'));
@@ -235,16 +233,33 @@ function compile(modules) {
     .src(['components/**/*.less'])
     .pipe(
       through2.obj(function (file, encoding, next) {
-        this.push(file.clone());
+        const { compile: { transformLess: transformLessContent } = {} } = getConfig();
+
+        // Replace content
+        const cloneFile = file.clone();
+        let content = file.contents.toString().replace(/^\uFEFF/, '');
+
+        if (transformLessContent) {
+          content = transformLessContent(content, cloneFile.path) || content;
+        }
+
+        cloneFile.contents = Buffer.from(content);
+
+        // Clone for css here since `this.push` will modify file.path
+        const cloneCssFile = cloneFile.clone();
+
+        this.push(cloneFile);
+
+        // Transform less file
         if (
           file.path.match(/(\/|\\)style(\/|\\)index\.less$/) ||
           file.path.match(/(\/|\\)style(\/|\\)v2-compatible-reset\.less$/)
         ) {
-          transformLess(file.path)
+          transformLess(cloneCssFile.contents.toString(), cloneCssFile.path)
             .then(css => {
-              file.contents = Buffer.from(css);
-              file.path = file.path.replace(/\.less$/, '.css');
-              this.push(file);
+              cloneCssFile.contents = Buffer.from(css);
+              cloneCssFile.path = cloneCssFile.path.replace(/\.less$/, '.css');
+              this.push(cloneCssFile);
               next();
             })
             .catch(e => {
@@ -303,35 +318,6 @@ function compile(modules) {
   const tsFilesStream = babelify(tsResult.js, modules);
   const tsd = tsResult.dts.pipe(gulp.dest(modules === false ? esDir : libDir));
   return merge2([less, tsFilesStream, tsd, assets]);
-}
-
-function compileLess() {
-  rimraf.sync(distDir);
-  return gulp
-    .src(['components/**/*.less'])
-    .pipe(
-      through2.obj(function (file, encoding, next) {
-        if (
-          file.path.match(/(\/|\\)style(\/|\\)index\.less$/) ||
-          file.path.match(/(\/|\\)style(\/|\\)v2-compatible-reset\.less$/)
-        ) {
-          transformLess(file.path)
-            .then(css => {
-              file.contents = Buffer.from(css);
-              file.path = file.path.replace(/\.less$/, '.css');
-              this.push(file);
-              next();
-            })
-            .catch(e => {
-              console.error(e);
-            });
-        } else {
-          next();
-        }
-      })
-    )
-    .pipe(concat('antd.css'))
-    .pipe(gulp.dest(distDir));
 }
 
 function publish(tagString, done) {
@@ -415,11 +401,6 @@ gulp.task(
   'compile',
   gulp.series(gulp.parallel('compile-with-es', 'compile-with-lib'), 'compile-finalize')
 );
-
-gulp.task('compile:less', done => {
-  console.log('Compile less...');
-  compileLess().on('finish', done);
-});
 
 gulp.task(
   'install',

--- a/lib/transformLess.js
+++ b/lib/transformLess.js
@@ -4,9 +4,11 @@ const path = require('path');
 const postcss = require('postcss');
 const autoprefixer = require('autoprefixer');
 const NpmImportPlugin = require('less-plugin-npm-import');
+const { getConfig } = require('./utils/projectHelper');
 
 function transformLess(lessFile, config = {}) {
   const { cwd = process.cwd() } = config;
+  const { compile: { lessConfig } = {} } = getConfig();
   const resolvedLessFile = path.resolve(cwd, lessFile);
 
   let data = readFileSync(resolvedLessFile, 'utf-8');
@@ -18,6 +20,7 @@ function transformLess(lessFile, config = {}) {
     filename: resolvedLessFile,
     plugins: [new NpmImportPlugin({ prefix: '~' })],
     javascriptEnabled: true,
+    ...lessConfig,
   };
   return less
     .render(data, lessOpts)

--- a/lib/transformLess.js
+++ b/lib/transformLess.js
@@ -1,18 +1,13 @@
 const less = require('less');
-const { readFileSync } = require('fs');
 const path = require('path');
 const postcss = require('postcss');
 const autoprefixer = require('autoprefixer');
 const NpmImportPlugin = require('less-plugin-npm-import');
-const { getConfig } = require('./utils/projectHelper');
 
-function transformLess(lessFile, config = {}) {
+
+function transformLess(lessContent, lessFilePath, config = {}) {
   const { cwd = process.cwd() } = config;
-  const { compile: { lessConfig } = {} } = getConfig();
-  const resolvedLessFile = path.resolve(cwd, lessFile);
-
-  let data = readFileSync(resolvedLessFile, 'utf-8');
-  data = data.replace(/^\uFEFF/, '');
+  const resolvedLessFile = path.resolve(cwd, lessFilePath);
 
   // Do less compile
   const lessOpts = {
@@ -20,10 +15,9 @@ function transformLess(lessFile, config = {}) {
     filename: resolvedLessFile,
     plugins: [new NpmImportPlugin({ prefix: '~' })],
     javascriptEnabled: true,
-    ...lessConfig,
   };
   return less
-    .render(data, lessOpts)
+    .render(lessContent, lessOpts)
     .then(result => postcss([autoprefixer]).process(result.css, { from: undefined }))
     .then(r => r.css);
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "glob": "^7.1.4",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",
-    "gulp-concat": "^2.6.1",
     "gulp-strip-code": "^0.1.4",
     "gulp-typescript": "^5.0.1",
     "gulp-watch": "^5.0.1",


### PR DESCRIPTION
编译时读取配置文件生成对应 css 文件。要和 webpack 区分开需要额外注入。先别合，我看看有没有更好的方式。

-------------

Update: 移除了 `compile:less`，需要发个大版本