### PR TITLE
feat: support for UMD bundles to be used on the ssr

### DIFF
--- a/lib/getWebpackConfig.js
+++ b/lib/getWebpackConfig.js
@@ -239,6 +239,7 @@ All rights reserved.
     };
     config.output.library = pkg.name;
     config.output.libraryTarget = 'umd';
+    config.output.globalObject = 'this';
     config.optimization = {
       minimizer: [
         new UglifyJsPlugin({


### PR DESCRIPTION
在 Next.js 中使用 antd v5 出现错误：[ReferenceError: window is not defined](https://github.com/ant-design/ant-design/discussions/36814#discussioncomment-3293917)。排查发现，[v5 移除 lib 产物](https://github.com/ant-design/ant-design/pull/36362)，仅提供 es 产物、 dist 产物（UMD）。webpack 4 构建时， `output.globalObject` 默认是 `window` ，而 node 没有 `window` 顶层对象，导致出现该错误。

ref:
- [webpack output.globalObject](https://webpack.js.org/configuration/output/#outputglobalobject)
- [Can't create UMD build which can be required by Node · Issue #6522 · webpack/webpack · GitHub](https://github.com/webpack/webpack/issues/6522)