### PR TITLE
feat: compile locale files

### DIFF
--- a/lib/gulpfile.js
+++ b/lib/gulpfile.js
@@ -7,12 +7,14 @@ const { execSync } = require('child_process');
 const through2 = require('through2');
 const webpack = require('webpack');
 const babel = require('gulp-babel');
+const esbuild = require('@umijs/bundler-utils/compiled/esbuild');
 const argv = require('minimist')(process.argv.slice(2));
 const chalk = require('chalk');
 const path = require('path');
 const watch = require('gulp-watch');
 const ts = require('gulp-typescript');
 const gulp = require('gulp');
+const glob = require('glob');
 const fs = require('fs');
 const rimraf = require('rimraf');
 const stripCode = require('gulp-strip-code');
@@ -37,6 +39,12 @@ const tsDefaultReporter = ts.reporter.defaultReporter();
 const cwd = process.cwd();
 const libDir = getProjectPath('lib');
 const esDir = getProjectPath('es');
+const localeDir = getProjectPath('locale');
+
+// FIXME: hard code, not find typescript can modify the path resolution
+const localeDts = `import type { Locale } from '../es/locale-provider';
+declare const localeValues: Locale;
+export default localeValues;`;
 
 function dist(done) {
   rimraf.sync(getProjectPath('dist'));
@@ -230,7 +238,7 @@ function babelify(js, modules, processLess = true) {
   return stream.pipe(gulp.dest(modules === false ? esDir : libDir));
 }
 
-function compile(modules, processLess = true) {
+function compile(modules, processLess = true, processLocale = true) {
   const { compile: { transformTSFile, transformFile, includeLessFile = [] } = {} } = getConfig();
   rimraf.sync(modules !== false ? libDir : esDir);
 
@@ -305,6 +313,12 @@ function compile(modules, processLess = true) {
     '!components/**/__tests__/**',
     '!components/**/demo/**',
   ];
+
+  // skip locale files
+  if (!processLocale) {
+    source.push('!components/**/locale/**');
+  }
+
   // allow jsx file in components/xxx/
   if (tsConfig.allowJs) {
     source.unshift('components/**/*.jsx');
@@ -353,6 +367,48 @@ function compile(modules, processLess = true) {
   const tsFilesStream = babelify(tsResult.js, modules, processLess);
   const tsd = tsResult.dts.pipe(gulp.dest(modules === false ? esDir : libDir));
   return merge2([less, tsFilesStream, tsd, assets, transformFileStream].filter(s => s));
+}
+
+function compileLocale(done) {
+  rimraf.sync(localeDir);
+
+  const entryPoints = glob.sync('components/locale/*.tsx');
+
+  esbuild.build({
+    entryPoints,
+    absWorkingDir: cwd,
+    format: 'cjs',
+    platform: 'node',
+    bundle: true,
+    outdir: localeDir,
+    logLevel: 'silent',
+    write: true,
+    charset: 'utf8',
+    plugins: [
+      {
+        name: 'antd-tools',
+        setup: builder => {
+          builder.onResolve({ filter: /.*/ }, args => {
+            // skip external modules
+            if (!args.path.startsWith('.')) {
+              return { path: args.path, external: true };
+            }
+            return {};
+          });
+
+          builder.onEnd(() => {
+            entryPoints.forEach(item => {
+              const match = item.match(/components\/locale\/(.*)\.tsx/);
+              if (match) {
+                fs.writeFileSync(`${localeDir}/${match[1]}.d.ts`, localeDts, 'utf8');
+              }
+            });
+            done();
+          });
+        },
+      },
+    ],
+  });
 }
 
 function publish(tagString, done) {
@@ -419,7 +475,12 @@ gulp.task('compile-with-es', done => {
 
 gulp.task('compile-with-es-experimental', done => {
   console.log('[Parallel] Compile to es...');
-  compile(false, false).on('finish', done);
+  compile(false, false, false).on('finish', done);
+});
+
+gulp.task('compile-with-locale', done => {
+  console.log('[Parallel] Compile locale files to js...');
+  compileLocale(done);
 });
 
 gulp.task('compile-with-lib', done => {
@@ -442,7 +503,13 @@ gulp.task(
   gulp.series(gulp.parallel('compile-with-es', 'compile-with-lib'), 'compile-finalize')
 );
 
-gulp.task('compile-experimental', gulp.series('compile-with-es-experimental', 'compile-finalize'));
+gulp.task(
+  'compile-experimental',
+  gulp.series(
+    gulp.parallel('compile-with-es-experimental', 'compile-with-locale'),
+    'compile-finalize'
+  )
+);
 
 gulp.task(
   'install',

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@babel/plugin-transform-typescript": "^7.10.5",
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
+    "@umijs/bundler-utils": "^4.0.26",
     "ansi-styles": "^4.0.0",
     "autoprefixer": "^10.0.1",
     "babel-jest": "^28.1.0",


### PR DESCRIPTION
新增语言包编译流程：
1. 仅打包 `components/locale` 到 `locale` 目录。
2. 内部依赖（如：`components/calendar/locale`）一起打包进来，外部依赖保持 external（如： `rc-pagination/lib/locale`）。
3. es 产物不再打包 `locale` 相关文件。

实现过程中遇到的两个问题：
1. father 暂不支持修改 esbuild 配置，打包无法达成上述预期。原本提了个 [PR feat: support configuring esbuild](https://github.com/umijs/father/pull/538)，后来和辟起讨论过程中，计划是通过插件机制去修改，但预计没那么快。目前是直接用 father 内部依赖的 esbuild 来打包，后续实现插件制特性后，可以快速迁移。
2. TypeScript 仅生成 `components/locale` 目录的类型声明文件，但语言包内部引用了其他文件，导致生成的类型文件有问题，暂没有找到 TypeScript 支持配置修改依赖解析路径。目前是写的硬代码，类型从 `es/locale-provider` 引用。

这两个问题，不知道有没更好的解决方式 : D

ref: 

- [[RFC] Provide commonjs locale file in v5](https://github.com/ant-design/ant-design/discussions/38107)
- [issues: ReferenceError: window is not defined after upgrading from v4 to v5 in Next.js](https://github.com/ant-design/ant-design/issues/37893)