### PR TITLE
fix: add @babel/plugin-transform-classes

### DIFF
--- a/lib/getBabelCommonConfig.js
+++ b/lib/getBabelCommonConfig.js
@@ -20,6 +20,7 @@ module.exports = function (modules) {
           require(`${process.cwd()}/package.json`).dependencies['@babel/runtime'] || '^7.10.4',
       },
     ],
+    resolve('@babel/plugin-transform-classes'),
     resolve('@babel/plugin-transform-spread'),
     [resolve('@babel/plugin-transform-template-literals'), { loose: true }],
     resolve('@babel/plugin-proposal-export-default-from'),

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@babel/plugin-proposal-export-default-from": "^7.2.0",
     "@babel/plugin-proposal-export-namespace-from": "^7.2.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.4.4",
+    "@babel/plugin-transform-classes": "^7.20.2",
     "@babel/plugin-transform-member-expression-literals": "^7.2.0",
     "@babel/plugin-transform-object-assign": "^7.2.0",
     "@babel/plugin-transform-property-literals": "^7.2.0",


### PR DESCRIPTION
fixed: https://github.com/ant-design/ant-design/actions/runs/3511777282/jobs/5882875095

原因分析：https://github.com/ant-design/ant-design/pull/38779/files 改变了 browserlist 的兼容版本

参考 https://github.com/babel/babel/pull/13075/files 变更的配置，可以推测当 babel preset env 设置的 browerlist 版本较新时，是不会编译 class 下的 `super(...arguments)` 语法的，需要配合 `@babel/plugin-transform-classes`，这样将 class 转为 function 后，就可以继续处理了

在 babeljs.io 的 playground 验证如下

不加 `@babel/plugin-transform-classes` 报错
![image](https://user-images.githubusercontent.com/6828924/202978155-c7939ea4-8bb8-45e4-b316-08a3b0abe6f3.png)

加 `@babel/plugin-transform-classes` 后编译成功
![image](https://user-images.githubusercontent.com/6828924/202978135-128654ad-edf7-4977-b0cf-29fc060ca8d5.png)



related: https://github.com/babel/babel/pull/12722

