### PR TITLE
chore: fix build of x

### DIFF
--- a/lib/getWebpackConfig.js
+++ b/lib/getWebpackConfig.js
@@ -41,7 +41,7 @@ function getWebpackConfig(modules) {
   ]);
 
   // Other package
-  if (pkg.name !== 'antd') {
+  if (pkg.name !== 'antd' && pkg.name !== '@ant-design/x') {
     babelConfig.plugins.push([
       resolve('babel-plugin-import'),
       {


### PR DESCRIPTION
`babel-plugin-import` 应该是没地方要用了，以防万一还是先通过条件判断来剥离。
在 antd 发布 v6 时，可以整体调整一下。把 `babel-plugin-import` 移除并且提升 `target` 版本不要再编译出兼容语法而降低运行时效率。