### PR TITLE
feat(sortApiTable): support process deprecated props

### DIFF
--- a/lib/sortApiTable.js
+++ b/lib/sortApiTable.js
@@ -26,7 +26,26 @@ const remarkWithYaml = unified()
 const stream = majo();
 
 function getCellValue(node) {
-  return node.children[0].children[0].value;
+  let cloneNode = { ...node };
+
+  while (cloneNode.type !== 'text' && cloneNode.children) {
+    [cloneNode] = cloneNode.children;
+  }
+
+  return cloneNode.value || '';
+}
+
+function checkForCellDeletion(node) {
+  let cloneNode = { ...node };
+
+  while (Array.isArray(cloneNode.children)) {
+    if (cloneNode.type === 'delete') {
+      return true;
+    }
+    [cloneNode] = cloneNode.children;
+  }
+
+  return cloneNode.type === 'delete';
 }
 
 // from small to large
@@ -37,6 +56,8 @@ const whiteMethodList = ['afterChange', 'beforeChange'];
 const groups = {
   isDynamic: val => /^on[A-Z]/.test(val) || whiteMethodList.indexOf(val) > -1,
   isSize: val => sizeBreakPoints.indexOf(val) > -1,
+  // https://github.com/ant-design/ant-design/pull/51342
+  isDeprecated: checkForCellDeletion,
 };
 
 function asciiSort(prev, next) {
@@ -72,6 +93,7 @@ function sort(ast, filename) {
     static: new Set(),
     size: new Set(),
     dynamic: new Set(),
+    deprecated: new Set(),
   };
 
   ast.children.forEach(child => {
@@ -81,13 +103,20 @@ function sort(ast, filename) {
     // one of ['xs', 'sm', 'md', 'lg', 'xl']
     const sizeProps = [];
 
+    // deprecated props ~~props~~
+    const deprecatedProps = [];
+
     // find table markdown type
     if (child.type === 'table') {
       // slice will create new array, so sort can affect the original array.
       // slice(1) cut down the thead
       child.children.slice(1).forEach(node => {
         const value = getCellValue(node);
-        if (groups.isDynamic(value)) {
+
+        if (groups.isDeprecated(node)) {
+          deprecatedProps.push(node);
+          fileAPIs[componentName].deprecated.add(value);
+        } else if (groups.isDynamic(value)) {
           dynamicProps.push(node);
           fileAPIs[componentName].dynamic.add(value);
         } else if (groups.isSize(value)) {
@@ -105,6 +134,8 @@ function sort(ast, filename) {
         ...alphabetSort(staticProps),
         ...sizeSort(sizeProps),
         ...alphabetSort(dynamicProps),
+        // deprecated props should be the last
+        ...alphabetSort(deprecatedProps),
       ];
     }
   });
@@ -151,6 +182,7 @@ module.exports = () => {
             static: [...fileAPIs[componentName].static],
             size: [...fileAPIs[componentName].size],
             dynamic: [...fileAPIs[componentName].dynamic],
+            deprecated: [...fileAPIs[componentName].deprecated],
           };
         });
 

--- a/lib/sortApiTable.js
+++ b/lib/sortApiTable.js
@@ -25,6 +25,10 @@ const remarkWithYaml = unified()
 
 const stream = majo();
 
+function get(obj, pathStr = '', defaultValue) {
+  return pathStr.split('.').reduce((acc, key) => acc && acc[key], obj) || defaultValue;
+}
+
 function getCellValue(node) {
   let cloneNode = { ...node };
 
@@ -150,7 +154,15 @@ function sortAPI(md, filename) {
 function sortMiddleware(ctx) {
   Object.keys(ctx.files).forEach(filename => {
     const content = ctx.fileContents(filename);
-    ctx.writeContents(filename, sortAPI(content, filename));
+
+    const sortedContent = sortAPI(content, filename);
+
+    if (get(ctx.meta, 'program.report', false)) {
+      console.log(chalk.cyan(`🔍 report ${filename}`));
+    } else {
+      // write the sorted content back to the file
+      ctx.writeContents(filename, sortedContent);
+    }
   });
 }
 
@@ -166,12 +178,21 @@ module.exports = () => {
       'components/**/index.+(zh-CN|en-US).md'
     )
     .option('-o, --output [output]', 'Specify component api output path', '~component-api.json')
+    .option('-r, --report', 'Only output the report, will not modify the file', false)
     .parse(process.argv);
   // Get the markdown file all need to be transformed
+
+  // inject context to the majo stream
+  function injectContext(ctx) {
+    if (typeof ctx.meta !== 'object') ctx.meta = {};
+
+    Object.assign(ctx.meta, { program });
+  }
 
   /* eslint-disable no-console */
   stream
     .source(program.file)
+    .use(injectContext)
     .use(sortMiddleware)
     .dest('.')
     .then(() => {


### PR DESCRIPTION
这么好的东西居然没发现，准备搞 v6 的话，可以用这个工具再统一处理一次 api table 的顺序

<img width="1555" alt="image" src="https://github.com/user-attachments/assets/f9c9378a-a86a-428e-8a5d-4160ac4093f8">
