### PR TITLE
feat: enhance file list fetching with Arborist and npm-packlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "webpackbar": "^5.0.0"
   },
   "devDependencies": {
+    "@npmcli/arborist": "^9.1.1",
     "@rc-component/father-plugin": "^2.1.2",
     "@types/fs-extra": "^11.0.4",
     "@types/glob": "^8.1.0",
@@ -122,6 +123,7 @@
     "eslint-plugin-react": "^7.13.0",
     "father": "^4.5.2",
     "jest": "^27.0.3",
+    "npm-packlist": "^10.0.0",
     "pre-commit": "1.x"
   },
   "pre-commit": [

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@babel/plugin-transform-typescript": "^7.10.5",
     "@babel/preset-env": "^7.4.5",
     "@babel/preset-react": "^7.0.0",
+    "@npmcli/arborist": "^9.1.1",
     "ansi-styles": "^4.0.0",
     "autoprefixer": "^10.0.1",
     "babel-jest": "^28.1.0",
@@ -76,6 +77,7 @@
     "minimist": "^1.2.0",
     "mkdirp": "^1.0.3",
     "node-fetch": "2.6.7",
+    "npm-packlist": "^10.0.0",
     "postcss": "^8.1.2",
     "postcss-loader": "^4.0.4",
     "prettier": "^2.0.1",
@@ -100,7 +102,6 @@
     "webpackbar": "^5.0.0"
   },
   "devDependencies": {
-    "@npmcli/arborist": "^9.1.1",
     "@rc-component/father-plugin": "^2.1.2",
     "@types/fs-extra": "^11.0.4",
     "@types/glob": "^8.1.0",
@@ -123,7 +124,6 @@
     "eslint-plugin-react": "^7.13.0",
     "father": "^4.5.2",
     "jest": "^27.0.3",
-    "npm-packlist": "^10.0.0",
     "pre-commit": "1.x"
   },
   "pre-commit": [

--- a/src/lint/checkDiff.ts
+++ b/src/lint/checkDiff.ts
@@ -96,7 +96,7 @@ export default function (
           chalk.yellow(`⚠️  Some file added in current build (last version: ${version}):`)
         );
         addedFiles.forEach(filePath => {
-          console.log(chalk.yellow(` + ${filePath}`));
+          console.log(` + ${filePath}`);
         });
 
         // Separator
@@ -110,7 +110,7 @@ export default function (
           chalk.red(`⚠️  Some file missing in current build (last version: ${version}):`)
         );
         missingFiles.forEach(filePath => {
-          console.log(chalk.red(` - ${filePath}`));
+          console.log(` - ${filePath}`);
         });
       }
 
@@ -125,7 +125,7 @@ export default function (
         chalk.green('✅ Nothing missing compare to latest version:'),
         chalk.gray(version)
       );
-      return Promise.resolve(true);
+      return 0;
     })
     .then(() => done())
     .catch(err => {


### PR DESCRIPTION


当前 package-diff 只检查了缺失部分，并没有检查有哪些新增。比如[ antd-mobile 5.39.0 出现了意外的产物](https://npmmirror.com/package/antd-mobile/files/cjs/components/ellipsis/~ellipsis.js?version=5.39.0)

<img width="926" alt="image" src="https://github.com/user-attachments/assets/dec3407a-b2cd-445b-8873-97b211615952" />



 一方便需要担心敏感信息泄漏，另一方便可能会导致 breakchange？本次 PR 加入了新增和差异检查。

（或许可以再加一个开关控制是否检查新增）


### before
![image](https://github.com/user-attachments/assets/1c8d6372-70bd-4b9b-a487-fc5c2300dcf4)

### after

<img width="880" alt="image" src="https://github.com/user-attachments/assets/7a280bd8-18b0-48d5-aec2-517da7120d9e" />
