### PR TITLE
fix: use native webpack progress plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,8 +97,7 @@
     "unified": "^8.0.0",
     "url-loader": "^4.0.0",
     "webpack": "^5.0.0",
-    "webpack-merge": "^4.2.1",
-    "webpackbar": "^5.0.0"
+    "webpack-merge": "^4.2.1"
   },
   "devDependencies": {
     "@rc-component/father-plugin": "^2.1.2",

--- a/src/getWebpackConfig.ts
+++ b/src/getWebpackConfig.ts
@@ -1,7 +1,6 @@
 import { getProjectPath, resolve } from './utils/projectHelper';
 import * as path from 'path';
 import * as webpack from 'webpack';
-import WebpackBar from 'webpackbar';
 import webpackMerge from 'webpack-merge';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
@@ -33,33 +32,6 @@ interface GetWebpackConfigFunction {
   svgRegex: RegExp;
   svgOptions: typeof svgOptions;
   imageOptions: typeof imageOptions;
-}
-
-const shouldFallbackToNativeProgressPlugin = () => {
-  const [major = 0, minor = 0] = webpack.version
-    .split('.')
-    .map((version) => Number.parseInt(version, 10));
-
-  return major > 5 || (major === 5 && minor >= 106);
-};
-
-class CompatibleProgressPlugin {
-  private readonly plugin: { apply(compiler: webpack.Compiler): void };
-
-  constructor() {
-    this.plugin = shouldFallbackToNativeProgressPlugin()
-      ? new webpack.ProgressPlugin({
-          activeModules: true,
-        })
-      : new WebpackBar({
-          name: '🚚  Ant Design Tools',
-          color: '#2f54eb',
-        });
-  }
-
-  apply(compiler: webpack.Compiler) {
-    this.plugin.apply(compiler);
-  }
 }
 
 const getWebpackConfig: GetWebpackConfigFunction = (modules, options = {}) => {
@@ -206,7 +178,9 @@ ${pkg.name} v${pkg.version}
 Copyright 2015-present, Alipay, Inc.
 All rights reserved.
       `),
-      new CompatibleProgressPlugin(),
+      new webpack.ProgressPlugin({
+        activeModules: true,
+      }),
       new CleanUpStatsPlugin(),
     ],
 

--- a/src/getWebpackConfig.ts
+++ b/src/getWebpackConfig.ts
@@ -35,6 +35,33 @@ interface GetWebpackConfigFunction {
   imageOptions: typeof imageOptions;
 }
 
+const shouldFallbackToNativeProgressPlugin = () => {
+  const [major = 0, minor = 0] = webpack.version
+    .split('.')
+    .map((version) => Number.parseInt(version, 10));
+
+  return major > 5 || (major === 5 && minor >= 106);
+};
+
+class CompatibleProgressPlugin {
+  private readonly plugin: { apply(compiler: webpack.Compiler): void };
+
+  constructor() {
+    this.plugin = shouldFallbackToNativeProgressPlugin()
+      ? new webpack.ProgressPlugin({
+          activeModules: true,
+        })
+      : new WebpackBar({
+          name: '🚚  Ant Design Tools',
+          color: '#2f54eb',
+        });
+  }
+
+  apply(compiler: webpack.Compiler) {
+    this.plugin.apply(compiler);
+  }
+}
+
 const getWebpackConfig: GetWebpackConfigFunction = (modules, options = {}) => {
   const { enabledReactCompiler } = options;
 
@@ -179,10 +206,7 @@ ${pkg.name} v${pkg.version}
 Copyright 2015-present, Alipay, Inc.
 All rights reserved.
       `),
-      new WebpackBar({
-        name: '🚚  Ant Design Tools',
-        color: '#2f54eb',
-      }),
+      new CompatibleProgressPlugin(),
       new CleanUpStatsPlugin(),
     ],
 


### PR DESCRIPTION
## Background

Webpack `5.106.0` validates `ProgressPlugin` options more strictly, which makes the current `webpackbar` integration fail during `dist` builds with an invalid options error.

## Solution

- remove `webpackbar` from `antd-tools`
- use native `webpack.ProgressPlugin` directly in `getWebpackConfig`
- avoid the invalid `ProgressPlugin` options path introduced by `webpackbar`

## Verification

- `ut run compile`
- `ut run lint`
- verified `antd` `dist` build passes with webpack `5.106.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **优化改进**
  * 用 webpack 内置进度插件替换了外部进度条库，简化了构建工具链依赖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->