### PR TITLE
fix: transform static class blocks before classes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,6 @@ jobs:
 
       - name: Run build
         run: bun run compile
+
+      - name: Run tests
+        run: bun run test

--- a/package.json
+++ b/package.json
@@ -32,11 +32,13 @@
     "compile": "father build",
     "prepublishOnly": "npm run compile",
     "lint": "eslint src",
-    "prettier": "node ./script/prettier.js"
+    "prettier": "node ./script/prettier.js",
+    "test": "jest tests"
   },
   "dependencies": {
     "@babel/core": "^7.4.5",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
+    "@babel/plugin-transform-class-static-block": "^7.29.7",
     "@babel/plugin-transform-classes": "^7.20.7",
     "@babel/plugin-transform-private-methods": "^7.25.9",
     "@babel/plugin-transform-runtime": "^7.4.4",

--- a/src/getBabelCommonConfig.ts
+++ b/src/getBabelCommonConfig.ts
@@ -28,6 +28,7 @@ function getBabelCommonConfig(modules?: boolean, options: BabelConfigOptions = {
       },
     ],
     resolve('@babel/plugin-transform-spread'),
+    resolve('@babel/plugin-transform-class-static-block'),
     resolve('@babel/plugin-proposal-class-properties'),
     resolve('@babel/plugin-transform-classes'),
     resolve('babel-plugin-transform-dev-warning'),

--- a/tests/fixtures/browserslist-project/package.json
+++ b/tests/fixtures/browserslist-project/package.json
@@ -1,0 +1,8 @@
+{
+  "browserslist": [
+    "defaults"
+  ],
+  "dependencies": {
+    "@babel/runtime": "^7.29.2"
+  }
+}

--- a/tests/getBabelCommonConfig.test.js
+++ b/tests/getBabelCommonConfig.test.js
@@ -1,0 +1,35 @@
+const { transformSync } = require('@babel/core');
+const path = require('path');
+
+describe('getBabelCommonConfig', () => {
+  it('transforms static class blocks before classes', () => {
+    const originalCwd = process.cwd();
+    process.chdir(path.join(__dirname, 'fixtures/browserslist-project'));
+
+    try {
+      const configPath = require.resolve('../lib/getBabelCommonConfig');
+      const projectHelperPath = require.resolve('../lib/utils/projectHelper');
+      delete require.cache[configPath];
+      delete require.cache[projectHelperPath];
+      const getBabelCommonConfig = require(configPath).default;
+
+      const { code } = transformSync(
+        `
+          export class Example {
+            #value;
+            static #ready;
+
+            static {
+              this.#ready = true;
+            }
+          }
+        `,
+        getBabelCommonConfig(),
+      );
+
+      expect(code).not.toContain('static {');
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+});


### PR DESCRIPTION
## What changed

- add `@babel/plugin-transform-class-static-block` to the shared Babel configuration before the class transforms
- add a regression test for projects that use a Browserslist configuration
- run the new test in CI after compiling the package

## Why

When a consuming project has a Browserslist configuration, Preset Env may leave static class blocks unchanged. The explicit class transform then fails before Preset Env can handle them, producing:

```text
Static class blocks are not enabled. Please add @babel/plugin-transform-class-static-block to your configuration.
```

This currently breaks the Jest image suites in ant-design/ant-design#58825 after upgrading to jsdom 30, whose selector dependency contains private fields and a static class block.

## Validation

- `bun run compile`
- `bun run test --runInBand`
- `bun run lint`

The regression test reproduces the failure without the plugin and passes with this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **兼容性改进**
  - 增强对包含私有字段和类静态初始化块代码的编译支持，提升不同浏览器环境下的运行兼容性。

- **测试**
  - 新增相关集成测试，验证编译结果符合预期。
  - 持续集成流程现会自动执行测试，帮助及早发现回归问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->